### PR TITLE
Clean names of prefect blocks

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -2,9 +2,9 @@ name: Python package
 
 on:
   push:
-    branches: [main]
+    branches: [feature/add-tests]
   pull_request:
-    branches: [main]
+    branches: [feature/add-tests]
 
 jobs:
   build:

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -2,9 +2,9 @@ name: Python package
 
 on:
   push:
-    branches: [feature/add-tests]
+    branches: [main]
   pull_request:
-    branches: [feature/add-tests]
+    branches: [main]
 
 jobs:
   build:

--- a/proxy/helpers.py
+++ b/proxy/helpers.py
@@ -1,6 +1,7 @@
 import re
 
-def cleaned_name_for_dbtblock(blockname):
+
+def cleaned_name_for_prefectblock(blockname):
     """removes characters which are not lowercase letters, digits or dashes"""
     pattern = re.compile(r"[^\-a-z0-9]")
     return re.sub(pattern, "", blockname.lower())

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -19,7 +19,7 @@ from dotenv import load_dotenv
 from logger import logger
 
 
-from proxy.helpers import cleaned_name_for_dbtblock
+from proxy.helpers import cleaned_name_for_prefectblock
 from proxy.exception import PrefectException
 from proxy.schemas import (
     AirbyteServerCreate,
@@ -139,7 +139,8 @@ async def create_airbyte_server_block(payload: AirbyteServerCreate) -> str:
         api_version=payload.apiVersion,
     )
     try:
-        await airbyteservercblock.save(payload.blockName)
+        block_name_for_save = cleaned_name_for_prefectblock(payload.blockName)
+        await airbyteservercblock.save(block_name_for_save)
     except Exception as error:
         logger.exception(error)
         raise PrefectException("failed to create airbyte server block") from error
@@ -218,7 +219,8 @@ async def create_airbyte_connection_block(
         connection_id=conninfo.connectionId,
     )
     try:
-        await connection_block.save(conninfo.connectionBlockName)
+        block_name_for_save = cleaned_name_for_prefectblock(conninfo.connectionBlockName)
+        await connection_block.save(block_name_for_save)
     except Exception as error:
         logger.exception(error)
         raise PrefectException(
@@ -273,7 +275,8 @@ async def create_shell_block(shell: PrefectShellSetup) -> str:
         commands=shell.commands, env=shell.env, working_dir=shell.workingDir
     )
     try:
-        await shell_operation_block.save(shell.blockName)
+        block_name_for_save = cleaned_name_for_prefectblock(shell.blockName)
+        await shell_operation_block.save(block_name_for_save)
     except Exception as error:
         logger.exception(error)
         raise PrefectException("failed to create shell block") from error
@@ -341,7 +344,7 @@ async def _create_dbt_cli_profile(payload: DbtCoreCreate) -> DbtCliProfile:
             target_configs=target_configs,
         )
         await dbt_cli_profile.save(
-            cleaned_name_for_dbtblock(payload.profile.name), overwrite=True
+            cleaned_name_for_prefectblock(payload.profile.name), overwrite=True
         )
     except Exception as error:
         logger.exception(error)
@@ -365,7 +368,7 @@ async def create_dbt_core_block(payload: DbtCoreCreate):
         project_dir=payload.project_dir,
         dbt_cli_profile=dbt_cli_profile,
     )
-    cleaned_blockname = cleaned_name_for_dbtblock(payload.blockName)
+    cleaned_blockname = cleaned_name_for_prefectblock(payload.blockName)
     try:
         await dbt_core_operation.save(cleaned_blockname, overwrite=True)
     except Exception as error:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,19 +4,47 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from proxy.main import (airbytesync, app, dbtrun, delete_block, delete_deployment,
-                  get_airbyte_connection_by_blockid,
-                  get_airbyte_connection_by_blockname, get_airbyte_server,
-                  get_dbtcore, get_flow_run_logs_paginated, get_flow_runs, get_flowrun, get_shell,
-                  post_airbyte_connection, post_airbyte_connection_blocks, post_airbyte_server, 
-                  post_bulk_delete_blocks, post_create_deployment_flow_run, post_dataflow,
-                  post_dbtcore, post_deployment_set_schedule, post_deployments, post_shell,
-                  sync_airbyte_connection_flow, sync_dbtcore_flow)
+from proxy.main import (
+    airbytesync,
+    app,
+    dbtrun,
+    delete_block,
+    delete_deployment,
+    get_airbyte_connection_by_blockid,
+    get_airbyte_connection_by_blockname,
+    get_airbyte_server,
+    get_dbtcore,
+    get_flow_run_logs_paginated,
+    get_flow_runs,
+    get_flowrun,
+    get_shell,
+    post_airbyte_connection,
+    post_airbyte_connection_blocks,
+    post_airbyte_server,
+    post_bulk_delete_blocks,
+    post_create_deployment_flow_run,
+    post_dataflow,
+    post_dbtcore,
+    post_deployment_set_schedule,
+    post_deployments,
+    post_shell,
+    sync_airbyte_connection_flow,
+    sync_dbtcore_flow,
+)
 
-from proxy.schemas import (AirbyteConnectionBlocksFetch, AirbyteConnectionCreate, AirbyteServerCreate,
-                     DbtCoreCreate, DbtProfileCreate, DeploymentCreate,
-                     DeploymentFetch, FlowRunRequest, PrefectBlocksDelete, PrefectShellSetup,
-                     RunFlow)
+from proxy.schemas import (
+    AirbyteConnectionBlocksFetch,
+    AirbyteConnectionCreate,
+    AirbyteServerCreate,
+    DbtCoreCreate,
+    DbtProfileCreate,
+    DeploymentCreate,
+    DeploymentFetch,
+    FlowRunRequest,
+    PrefectBlocksDelete,
+    PrefectShellSetup,
+    RunFlow,
+)
 
 app = FastAPI()
 client = TestClient(app)
@@ -28,9 +56,13 @@ def test_airbytesync_success():
     flow_run_name = "example_flow_run"
     inner_result = {"status": "success", "result": "example_result"}
     expected_result = {"status": "success", "result": inner_result}
-    
-    with patch("proxy.main.run_airbyte_connection_flow") as mock_run_airbyte_connection_flow:
-        with patch.object(mock_run_airbyte_connection_flow.with_options.return_value, "with_options") as mock_with_options:
+
+    with patch(
+        "proxy.main.run_airbyte_connection_flow"
+    ) as mock_run_airbyte_connection_flow:
+        with patch.object(
+            mock_run_airbyte_connection_flow.with_options.return_value, "with_options"
+        ) as mock_with_options:
             mock_with_options.return_value = lambda x: inner_result
             result = airbytesync(block_name, flow_name, flow_run_name)
             assert result == expected_result
@@ -42,9 +74,13 @@ def test_airbytesync_failure():
     flow_run_name = "example_flow_run"
     inner_result = {"status": "failed", "result": "example_failure_result"}
     expected_result = {"status": "success", "result": inner_result}
-    
-    with patch("proxy.main.run_airbyte_connection_flow") as mock_run_airbyte_connection_flow:
-        with patch.object(mock_run_airbyte_connection_flow.with_options.return_value, "with_options") as mock_with_options:
+
+    with patch(
+        "proxy.main.run_airbyte_connection_flow"
+    ) as mock_run_airbyte_connection_flow:
+        with patch.object(
+            mock_run_airbyte_connection_flow.with_options.return_value, "with_options"
+        ) as mock_with_options:
             mock_with_options.return_value = lambda x: inner_result
             result = airbytesync(block_name, flow_name, flow_run_name)
             assert result == expected_result
@@ -54,7 +90,7 @@ def test_airbyte_sync_with_invalid_block_name():
     invalid_block_name = None
     flow_name = "example_flow"
     flow_run_name = "example_flow_run"
-    
+
     with pytest.raises(Exception):
         airbytesync(invalid_block_name, flow_name, flow_run_name)
 
@@ -63,7 +99,7 @@ def test_airbyte_sync_invalid_flow_name():
     block_name = "example_block"
     invalid_flow_name = None
     flow_run_name = "example_flow_run"
-    
+
     with pytest.raises(Exception):
         airbytesync(block_name, invalid_flow_name, flow_run_name)
 
@@ -72,7 +108,7 @@ def test_airbyte_sync_invalid_flow_run_name():
     block_name = "example_block"
     flow_name = "example_flow"
     invalid_flow_run_name = None
-    
+
     with pytest.raises(Exception):
         airbytesync(block_name, flow_name, invalid_flow_run_name)
 
@@ -82,21 +118,26 @@ def test_dbtrun_success():
     flow_name = "example_flow"
     flow_run_name = "example_flow_run"
     expected_result = {"result": "example_result"}
-    
+
     with patch("proxy.main.run_dbtcore_flow") as mock_run_dbtcore_flow:
-        with patch.object(mock_run_dbtcore_flow.with_options.return_value, "with_options") as mock_with_options:
+        with patch.object(
+            mock_run_dbtcore_flow.with_options.return_value, "with_options"
+        ) as mock_with_options:
             mock_with_options.return_value = lambda x: expected_result
             result = dbtrun(block_name, flow_name, flow_run_name)
             assert result == expected_result
+
 
 def test_dbtrun_failure():
     block_name = "example_block"
     flow_name = "example_flow"
     flow_run_name = "example_flow_run"
     expected_result = {"result": "example_failure_result", "status": "failed"}
-    
+
     with patch("proxy.main.run_dbtcore_flow") as mock_run_dbtcore_flow:
-        with patch.object(mock_run_dbtcore_flow.with_options.return_value, "with_options") as mock_with_options:
+        with patch.object(
+            mock_run_dbtcore_flow.with_options.return_value, "with_options"
+        ) as mock_with_options:
             mock_with_options.return_value = lambda x: expected_result
             result = dbtrun(block_name, flow_name, flow_run_name)
             assert result == expected_result
@@ -107,10 +148,10 @@ def test_run_dbt_exception():
     flow_name = "example_flow"
     flow_run_name = "example_flow_run"
     expected_result = {"result": "example_failure_result", "status": "failed"}
-    
+
     def mock_with_options(*args, **kwargs):
         raise HTTPException(status_code=400, detail="Job 12345 failed.")
-    
+
     with patch("proxy.main.run_dbtcore_flow.with_options", new=mock_with_options):
         try:
             result = dbtrun(block_name, flow_name, flow_run_name)
@@ -124,7 +165,7 @@ def test_dbtrun_invalid_block_name():
     block_name = None
     flow_name = "example_flow"
     flow_run_name = "example_flow_run"
-    
+
     with pytest.raises(TypeError):
         dbtrun(block_name, flow_name, flow_run_name)
 
@@ -133,7 +174,7 @@ def test_dbtrun_invalid_flow_name():
     block_name = "example_block"
     flow_name = None
     flow_run_name = "example_flow_run"
-    
+
     with pytest.raises(TypeError):
         dbtrun(block_name, flow_name, flow_run_name)
 
@@ -142,42 +183,55 @@ def test_dbtrun_invalid_flow_run_name():
     block_name = "example_block"
     flow_name = "example_flow"
     flow_run_name = None
-    
+
     with pytest.raises(TypeError):
         dbtrun(block_name, flow_name, flow_run_name)
 
+
 @pytest.mark.asyncio
 async def test_post_bulk_delete_blocks_success():
-    payload = PrefectBlocksDelete(block_ids=['12345', '67890'])
-    with patch('proxy.main.requests.delete') as mock_delete:
+    payload = PrefectBlocksDelete(block_ids=["12345", "67890"])
+    with patch("proxy.main.requests.delete") as mock_delete:
         mock_delete.return_value.raise_for_status.return_value = None
         response = await post_bulk_delete_blocks(payload)
-        assert response == {'deleted_blockids': ['12345', '67890']}
+        assert response == {"deleted_blockids": ["12345", "67890"]}
+
 
 def test_post_airbyte_connection_blocks_success():
-    payload = AirbyteConnectionBlocksFetch(block_names=['test_block'])
-    with patch('proxy.main.post_filter_blocks', return_value=[{'name': 'test_block', 'data': {'connection_id': '12345'}, 'id': '67890'}]):
+    payload = AirbyteConnectionBlocksFetch(block_names=["test_block"])
+    with patch(
+        "proxy.main.post_filter_blocks",
+        return_value=[
+            {"name": "test_block", "data": {"connection_id": "12345"}, "id": "67890"}
+        ],
+    ):
         response = post_airbyte_connection_blocks(payload)
-        assert response == [{'name': 'test_block', 'connectionId': '12345', 'id': '67890'}]
+        assert response == [
+            {"name": "test_block", "connectionId": "12345", "id": "67890"}
+        ]
 
 
 @pytest.mark.asyncio
 async def test_get_airbyte_server_success():
-    with patch('proxy.main.get_airbyte_server_block_id', return_value='12345'):
-        response = await get_airbyte_server('test_block')
-        assert response == {'block_id': '12345'}
+    with patch("proxy.main.get_airbyte_server_block_id", return_value="12345"):
+        response = await get_airbyte_server("test_block")
+        assert response == {"block_id": "12345"}
+
 
 @pytest.mark.asyncio
 async def test_get_airbyte_server_failure():
-    with patch('proxy.main.get_airbyte_server_block_id', return_value=None):
+    with patch("proxy.main.get_airbyte_server_block_id", return_value=None):
         with pytest.raises(HTTPException) as excinfo:
-            await get_airbyte_server('test_block')
+            await get_airbyte_server("test_block")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'no block having name test_block'
+        assert excinfo.value.detail == "no block having name test_block"
+
 
 @pytest.mark.asyncio
 async def test_get_airbyte_server_invalid_blockname():
-    with patch("proxy.main.get_airbyte_server_block_id") as get_airbyte_server_block_id_mock:
+    with patch(
+        "proxy.main.get_airbyte_server_block_id"
+    ) as get_airbyte_server_block_id_mock:
         get_airbyte_server_block_id_mock.return_value = None
         blockname = "invalid_blockname"
         with pytest.raises(HTTPException) as exc_info:
@@ -185,62 +239,72 @@ async def test_get_airbyte_server_invalid_blockname():
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "no block having name " + blockname
 
+
 @pytest.mark.asyncio
 async def test_post_airbyte_server_success():
     payload = AirbyteServerCreate(
-        blockName='test_server',
-        serverHost='http://test-server.com',
+        blockName="testserver",
+        serverHost="http://test-server.com",
         serverPort=8000,
-        apiVersion='v1'
+        apiVersion="v1",
     )
-    with patch('proxy.main.create_airbyte_server_block', return_value='12345'):
+    with patch("proxy.main.create_airbyte_server_block", return_value="12345"):
         response = await post_airbyte_server(payload)
-        assert response == {'block_id': '12345'}
+        assert response == {"block_id": "12345"}
+
 
 @pytest.mark.asyncio
 async def test_post_airbyte_server_failure():
     payload = AirbyteServerCreate(
-        blockName='test_server',
-        serverHost='http://test-server.com',
+        blockName="testserver",
+        serverHost="http://test-server.com",
         serverPort=8000,
-        apiVersion='v1'
+        apiVersion="v1",
     )
-    with patch('proxy.main.create_airbyte_server_block', side_effect=Exception('test error')):
+    with patch(
+        "proxy.main.create_airbyte_server_block", side_effect=Exception("test error")
+    ):
         with pytest.raises(HTTPException) as excinfo:
             await post_airbyte_server(payload)
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to create airbyte server block'
+        assert excinfo.value.detail == "failed to create airbyte server block"
+
 
 @pytest.mark.asyncio
 async def test_post_airbyte_server_with_invalid_payload():
     payload = AirbyteServerCreate(
-        blockName='test_server',
-        serverHost='http://test-server.com',
+        blockName="testserver",
+        serverHost="http://test-server.com",
         serverPort=8000,
-        apiVersion='v1'
+        apiVersion="v1",
     )
     with pytest.raises(HTTPException) as excinfo:
         await post_airbyte_server(payload)
     assert excinfo.value.status_code == 400
-    assert excinfo.value.detail == 'failed to create airbyte server block'
+    assert excinfo.value.detail == "failed to create airbyte server block"
+
 
 @pytest.mark.asyncio
 async def test_get_airbyte_connection_by_blockname_success():
-    with patch('proxy.main.get_airbyte_connection_block_id', return_value='12345'):
-        response = await get_airbyte_connection_by_blockname('test_block')
-        assert response == {'block_id': '12345'}
+    with patch("proxy.main.get_airbyte_connection_block_id", return_value="12345"):
+        response = await get_airbyte_connection_by_blockname("test_block")
+        assert response == {"block_id": "12345"}
+
 
 @pytest.mark.asyncio
 async def test_get_airbyte_connection_by_blockname_failure():
-    with patch('proxy.main.get_airbyte_connection_block_id', return_value=None):
+    with patch("proxy.main.get_airbyte_connection_block_id", return_value=None):
         with pytest.raises(HTTPException) as excinfo:
-            await get_airbyte_connection_by_blockname('test_block')
+            await get_airbyte_connection_by_blockname("test_block")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'no block having name test_block'
+        assert excinfo.value.detail == "no block having name test_block"
+
 
 @pytest.mark.asyncio
 async def test_get_airbyte_connection_by_blockname_invalid_blockname():
-    with patch("proxy.main.get_airbyte_connection_block_id") as get_airbyte_connection_block_id_mock:
+    with patch(
+        "proxy.main.get_airbyte_connection_block_id"
+    ) as get_airbyte_connection_block_id_mock:
         get_airbyte_connection_block_id_mock.return_value = None
         blockname = "invalid_blockname"
         with pytest.raises(HTTPException) as exc_info:
@@ -248,24 +312,29 @@ async def test_get_airbyte_connection_by_blockname_invalid_blockname():
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "no block having name " + blockname
 
+
 @pytest.mark.asyncio
 async def test_get_airbyte_connection_by_blockid_success():
-    block_data = {'id': '12345', 'name': 'test_block', 'url': 'http://test-block.com'}
-    with patch('proxy.main.get_airbyte_connection_block', return_value=block_data):
-        response = await get_airbyte_connection_by_blockid('12345')
+    block_data = {"id": "12345", "name": "test_block", "url": "http://test-block.com"}
+    with patch("proxy.main.get_airbyte_connection_block", return_value=block_data):
+        response = await get_airbyte_connection_by_blockid("12345")
         assert response == block_data
+
 
 @pytest.mark.asyncio
 async def test_get_airbyte_connection_by_blockid_failure():
-    with patch('proxy.main.get_airbyte_connection_block', return_value=None):
+    with patch("proxy.main.get_airbyte_connection_block", return_value=None):
         with pytest.raises(HTTPException) as excinfo:
-            await get_airbyte_connection_by_blockid('12345')
+            await get_airbyte_connection_by_blockid("12345")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'no block having id 12345'
+        assert excinfo.value.detail == "no block having id 12345"
+
 
 @pytest.mark.asyncio
 async def test_get_airbyte_connection_by_blockid_invalid_blockid():
-    with patch("proxy.main.get_airbyte_connection_block") as get_airbyte_connection_block_mock:
+    with patch(
+        "proxy.main.get_airbyte_connection_block"
+    ) as get_airbyte_connection_block_mock:
         get_airbyte_connection_block_mock.return_value = None
         blockid = "invalid_blockid"
         with pytest.raises(HTTPException) as exc_info:
@@ -277,329 +346,360 @@ async def test_get_airbyte_connection_by_blockid_invalid_blockid():
 @pytest.mark.asyncio
 async def test_post_airbyte_connection_success():
     payload = AirbyteConnectionCreate(
-        serverBlockName='test_server',
-        connectionId='12345',
-        connectionBlockName='test_connection'
+        serverBlockName="testserver",
+        connectionId="12345",
+        connectionBlockName="test_connection",
     )
-    with patch('proxy.main.create_airbyte_connection_block', return_value='12345'):
+    with patch("proxy.main.create_airbyte_connection_block", return_value="12345"):
         response = await post_airbyte_connection(payload)
-        assert response == {'block_id': '12345'}
+        assert response == {"block_id": "12345"}
+
 
 @pytest.mark.asyncio
 async def test_post_airbyte_connection_failure():
     payload = AirbyteConnectionCreate(
-        serverBlockName='test_server',
-        connectionId='12345',
-        connectionBlockName='test_connection'
+        serverBlockName="testserver",
+        connectionId="12345",
+        connectionBlockName="test_connection",
     )
-    with patch('proxy.main.create_airbyte_connection_block', side_effect=Exception('test error')):
+    with patch(
+        "proxy.main.create_airbyte_connection_block",
+        side_effect=Exception("test error"),
+    ):
         with pytest.raises(HTTPException) as excinfo:
             await post_airbyte_connection(payload)
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to create airbyte connection block'
+        assert excinfo.value.detail == "failed to create airbyte connection block"
 
 
 @pytest.mark.asyncio
 async def test_post_airbyte_connection_with_invalid_payload():
     payload = AirbyteConnectionCreate(
-        serverBlockName='test_server',
-        connectionId='12345',
-        connectionBlockName='test_connection'
+        serverBlockName="testserver",
+        connectionId="12345",
+        connectionBlockName="test_connection",
     )
     with pytest.raises(HTTPException) as excinfo:
         await post_airbyte_connection(payload)
     assert excinfo.value.status_code == 400
-    assert excinfo.value.detail == 'failed to create airbyte connection block'
+    assert excinfo.value.detail == "failed to create airbyte connection block"
 
 
 @pytest.mark.asyncio
 async def test_get_shell_success():
-    with patch('proxy.main.get_shell_block_id', return_value='12345'):
-        response = await get_shell('test_block')
-        assert response == {'block_id': '12345'}
+    with patch("proxy.main.get_shell_block_id", return_value="12345"):
+        response = await get_shell("test_block")
+        assert response == {"block_id": "12345"}
+
 
 @pytest.mark.asyncio
 async def test_get_shell_failure():
-    with patch('proxy.main.get_shell_block_id', return_value=None):
+    with patch("proxy.main.get_shell_block_id", return_value=None):
         with pytest.raises(HTTPException) as excinfo:
-            await get_shell('test_block')
+            await get_shell("test_block")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'no block having name test_block'
+        assert excinfo.value.detail == "no block having name test_block"
+
 
 @pytest.mark.asyncio
 async def test_post_shell_success():
     payload = PrefectShellSetup(
-        blockName='test_shell',
+        blockName="test_shell",
         commands=['echo "Hello, World!"'],
-        workingDir='test_dir',
-        env={
-            'TEST_ENV': 'test_value'}
+        workingDir="test_dir",
+        env={"TEST_ENV": "test_value"},
     )
-    with patch('proxy.main.create_shell_block', return_value='12345'):
+    with patch("proxy.main.create_shell_block", return_value="12345"):
         response = await post_shell(payload)
-        assert response == {'block_id': '12345'}
+        assert response == {"block_id": "12345"}
+
 
 @pytest.mark.asyncio
 async def test_post_shell_failure():
     payload = PrefectShellSetup(
-        blockName='test_shell',
+        blockName="test_shell",
         commands=['echo "Hello, World!"'],
-        workingDir='test_dir',
-        env={
-            'TEST_ENV': 'test_value'}
+        workingDir="test_dir",
+        env={"TEST_ENV": "test_value"},
     )
-    with patch('proxy.main.create_shell_block', side_effect=Exception('test error')):
+    with patch("proxy.main.create_shell_block", side_effect=Exception("test error")):
         with pytest.raises(HTTPException) as excinfo:
             await post_shell(payload)
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to create shell block'
+        assert excinfo.value.detail == "failed to create shell block"
 
 
 @pytest.mark.asyncio
 async def test_get_dbtcore_success():
-    with patch('proxy.main.get_dbtcore_block_id', return_value='12345'):
-        response = await get_dbtcore('test_block')
-        assert response == {'block_id': '12345'}
+    with patch("proxy.main.get_dbtcore_block_id", return_value="12345"):
+        response = await get_dbtcore("test_block")
+        assert response == {"block_id": "12345"}
+
 
 @pytest.mark.asyncio
 async def test_get_dbtcore_failure():
-    with patch('proxy.main.get_dbtcore_block_id', return_value=None):
+    with patch("proxy.main.get_dbtcore_block_id", return_value=None):
         with pytest.raises(HTTPException) as excinfo:
-            await get_dbtcore('test_block')
+            await get_dbtcore("test_block")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'no block having name test_block'
+        assert excinfo.value.detail == "no block having name test_block"
+
 
 @pytest.mark.asyncio
 async def test_post_dbtcore_success():
     payload = DbtCoreCreate(
-        blockName='test_dbt',
+        blockName="test_dbt",
         profile=DbtProfileCreate(
             name="test_profile",
             target="test_target",
             target_configs_schema="test_schema",
         ),
         wtype="postgres",
-        credentials={'TEST_CREDS': 'test_creds'},
+        credentials={"TEST_CREDS": "test_creds"},
         commands=['echo "Hello, World!"'],
-        env={
-            'TEST_ENV': 'test_value'
-        },
+        env={"TEST_ENV": "test_value"},
         working_dir="test_dir",
         profiles_dir="test_profiles_dir",
         project_dir="test_project_dir",
     )
-    with patch('proxy.main.create_dbt_core_block', return_value=('12345', 'test_dbt_cleaned')):
+    with patch(
+        "proxy.main.create_dbt_core_block", return_value=("12345", "test_dbt_cleaned")
+    ):
         response = await post_dbtcore(payload)
-        assert response == {'block_id': '12345', 'block_name': 'test_dbt_cleaned'}
+        assert response == {"block_id": "12345", "block_name": "test_dbt_cleaned"}
+
 
 @pytest.mark.asyncio
 async def test_post_dbtcore_failure():
     payload = DbtCoreCreate(
-        blockName='test_dbt',
+        blockName="test_dbt",
         profile=DbtProfileCreate(
             name="test_profile",
             target="test_target",
             target_configs_schema="test_schema",
         ),
         wtype="postgres",
-        credentials={'TEST_CREDS': 'test_creds'},
+        credentials={"TEST_CREDS": "test_creds"},
         commands=['echo "Hello, World!"'],
-        env={
-            'TEST_ENV': 'test_value'
-        },
+        env={"TEST_ENV": "test_value"},
         working_dir="test_dir",
         profiles_dir="test_profiles_dir",
         project_dir="test_project_dir",
     )
-    with patch('proxy.main.create_dbt_core_block', side_effect=Exception('test error')):
+    with patch("proxy.main.create_dbt_core_block", side_effect=Exception("test error")):
         with pytest.raises(HTTPException) as excinfo:
             await post_dbtcore(payload)
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to create dbt core block'
+        assert excinfo.value.detail == "failed to create dbt core block"
 
 
 @pytest.mark.asyncio
 async def test_delete_block_success():
-    with patch('proxy.main.requests.delete') as mock_delete:
+    with patch("proxy.main.requests.delete") as mock_delete:
         mock_delete.return_value.status_code = 204
-        response = await delete_block('12345')
+        response = await delete_block("12345")
         assert response is None
+
 
 @pytest.mark.asyncio
 async def test_delete_block_failure():
-    with patch('proxy.main.requests.delete') as mock_delete:
-        mock_delete.return_value.raise_for_status.side_effect = Exception('test error')
-        mock_delete.return_value.text = 'test error'
+    with patch("proxy.main.requests.delete") as mock_delete:
+        mock_delete.return_value.raise_for_status.side_effect = Exception("test error")
+        mock_delete.return_value.text = "test error"
         with pytest.raises(HTTPException) as excinfo:
-            await delete_block('12345')
+            await delete_block("12345")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'test error'
+        assert excinfo.value.detail == "test error"
 
 
 @pytest.mark.asyncio
 async def test_sync_airbyte_connection_flow_success():
-    payload = RunFlow(blockName='test_block', flowName='test_flow', flowRunName='test_flow_run')
-    with patch('proxy.main.airbytesync', return_value='test result'):
+    payload = RunFlow(
+        blockName="test_block", flowName="test_flow", flowRunName="test_flow_run"
+    )
+    with patch("proxy.main.airbytesync", return_value="test result"):
         response = await sync_airbyte_connection_flow(payload)
-        assert response == 'test result'
+        assert response == "test result"
 
 
 @pytest.mark.asyncio
 async def test_sync_airbyte_connection_flow_failure():
-    payload = RunFlow(blockName='', flowName='test_flow', flowRunName='test_flow_run')
+    payload = RunFlow(blockName="", flowName="test_flow", flowRunName="test_flow_run")
     with pytest.raises(HTTPException) as excinfo:
         await sync_airbyte_connection_flow(payload)
     assert excinfo.value.status_code == 400
-    assert excinfo.value.detail == 'received empty blockName'
+    assert excinfo.value.detail == "received empty blockName"
+
 
 @pytest.mark.asyncio
 async def test_sync_dbtcore_flow_success():
-    payload = RunFlow(blockName='test_block', flowName='test_flow', flowRunName='test_flow_run')
-    with patch('proxy.main.dbtrun', return_value='test result'):
+    payload = RunFlow(
+        blockName="test_block", flowName="test_flow", flowRunName="test_flow_run"
+    )
+    with patch("proxy.main.dbtrun", return_value="test result"):
         response = await sync_dbtcore_flow(payload)
-        assert response == {'status': 'success', 'result': 'test result'}
+        assert response == {"status": "success", "result": "test result"}
 
 
 @pytest.mark.asyncio
 async def test_sync_dbtcore_flow_failure():
-    payload = RunFlow(blockName='', flowName='test_flow', flowRunName='test_flow_run')
+    payload = RunFlow(blockName="", flowName="test_flow", flowRunName="test_flow_run")
     with pytest.raises(HTTPException) as excinfo:
         await sync_dbtcore_flow(payload)
     assert excinfo.value.status_code == 400
-    assert excinfo.value.detail == 'received empty blockName'
+    assert excinfo.value.detail == "received empty blockName"
 
 
 @pytest.mark.asyncio
 async def test_post_dataflow_success():
     payload = DeploymentCreate(
-        flow_name='test_block',
-        deployment_name='FULL',
-        org_slug='test_org',
-        connection_blocks=[{'name': 'test_block'}],
-        dbt_blocks=[{'name': 'test_block'}],
-        cron='* * * * *'
+        flow_name="test_block",
+        deployment_name="FULL",
+        org_slug="test_org",
+        connection_blocks=[{"name": "test_block"}],
+        dbt_blocks=[{"name": "test_block"}],
+        cron="* * * * *",
     )
-    with patch('proxy.main.post_deployment', return_value={'id': '67890'}):
+    with patch("proxy.main.post_deployment", return_value={"id": "67890"}):
         response = await post_dataflow(payload)
-        assert response == {'deployment': {'id': '67890'}}
+        assert response == {"deployment": {"id": "67890"}}
+
 
 @pytest.mark.asyncio
 async def test_post_dataflow_failure():
     payload = DeploymentCreate(
-        flow_name='test_block',
-        deployment_name='FULL',
-        org_slug='test_org',
-        connection_blocks=[{'name': 'test_block'}],
-        dbt_blocks=[{'name': 'test_block'}],
-        cron='* * * * *'
+        flow_name="test_block",
+        deployment_name="FULL",
+        org_slug="test_org",
+        connection_blocks=[{"name": "test_block"}],
+        dbt_blocks=[{"name": "test_block"}],
+        cron="* * * * *",
     )
-    with patch('proxy.main.post_deployment', side_effect=Exception('test error')):
+    with patch("proxy.main.post_deployment", side_effect=Exception("test error")):
         with pytest.raises(HTTPException) as excinfo:
             await post_dataflow(payload)
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to create deployment'
+        assert excinfo.value.detail == "failed to create deployment"
+
 
 @pytest.mark.asyncio
 async def test_get_flowrun_success():
-    payload = FlowRunRequest(name='test_flow_run')
-    with patch('proxy.main.get_flow_runs_by_name', return_value=[{'id': '12345'}]):
+    payload = FlowRunRequest(name="test_flow_run")
+    with patch("proxy.main.get_flow_runs_by_name", return_value=[{"id": "12345"}]):
         response = await get_flowrun(payload)
-        assert response == {'flow_run': {'id': '12345'}}
+        assert response == {"flow_run": {"id": "12345"}}
+
 
 @pytest.mark.asyncio
 async def test_get_flowrun_failure():
-    payload = FlowRunRequest(name='test_flow_run')
-    with patch('proxy.main.get_flow_runs_by_name', return_value=[]):
+    payload = FlowRunRequest(name="test_flow_run")
+    with patch("proxy.main.get_flow_runs_by_name", return_value=[]):
         with pytest.raises(HTTPException) as excinfo:
             await get_flowrun(payload)
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'no such flow run'
+        assert excinfo.value.detail == "no such flow run"
+
 
 def test_get_flow_runs_success():
-    with patch('proxy.main.get_flow_runs_by_deployment_id', return_value=[{'id': '12345'}]):
-        response = get_flow_runs('67890')
-        assert response == {'flow_runs': [{'id': '12345'}]}
+    with patch(
+        "proxy.main.get_flow_runs_by_deployment_id", return_value=[{"id": "12345"}]
+    ):
+        response = get_flow_runs("67890")
+        assert response == {"flow_runs": [{"id": "12345"}]}
 
 
 def test_get_flow_runs_failure():
-    with patch('proxy.main.get_flow_runs_by_deployment_id', side_effect=Exception('test error')):
+    with patch(
+        "proxy.main.get_flow_runs_by_deployment_id", side_effect=Exception("test error")
+    ):
         with pytest.raises(HTTPException) as excinfo:
-            get_flow_runs('67890')
+            get_flow_runs("67890")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to fetch flow_runs for deployment'
+        assert excinfo.value.detail == "failed to fetch flow_runs for deployment"
+
 
 def test_post_deployments_success():
-    payload = DeploymentFetch(org_slug='test_org', deployment_ids=['12345'])
-    with patch('proxy.main.get_deployments_by_filter', return_value=[{'id': '12345'}]):
+    payload = DeploymentFetch(org_slug="test_org", deployment_ids=["12345"])
+    with patch("proxy.main.get_deployments_by_filter", return_value=[{"id": "12345"}]):
         response = post_deployments(payload)
-        assert response == {'deployments': [{'id': '12345'}]}
+        assert response == {"deployments": [{"id": "12345"}]}
 
 
 def test_post_deployments_failure():
-    payload = DeploymentFetch(org_slug='test_org', deployment_ids=['12345'])
-    with patch('proxy.main.get_deployments_by_filter', side_effect=Exception('test error')):
+    payload = DeploymentFetch(org_slug="test_org", deployment_ids=["12345"])
+    with patch(
+        "proxy.main.get_deployments_by_filter", side_effect=Exception("test error")
+    ):
         with pytest.raises(HTTPException) as excinfo:
             post_deployments(payload)
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to filter deployments'
+        assert excinfo.value.detail == "failed to filter deployments"
 
 
 def test_get_flow_run_logs_paginated_success():
-    with patch('proxy.main.get_flow_run_logs', return_value='test logs'):
-        response = get_flow_run_logs_paginated('12345')
-        assert response == 'test logs'
+    with patch("proxy.main.get_flow_run_logs", return_value="test logs"):
+        response = get_flow_run_logs_paginated("12345")
+        assert response == "test logs"
+
 
 def test_get_flow_run_logs_paginated_failure():
-    with patch('proxy.main.get_flow_run_logs', side_effect=Exception('test error')):
+    with patch("proxy.main.get_flow_run_logs", side_effect=Exception("test error")):
         with pytest.raises(HTTPException) as excinfo:
-            get_flow_run_logs_paginated('12345')
+            get_flow_run_logs_paginated("12345")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to fetch logs for flow_run'
+        assert excinfo.value.detail == "failed to fetch logs for flow_run"
+
 
 def test_delete_deployment_success():
-    with patch('proxy.main.requests.delete') as mock_delete:
+    with patch("proxy.main.requests.delete") as mock_delete:
         mock_delete.return_value.raise_for_status.return_value = None
-        response = delete_deployment('12345')
+        response = delete_deployment("12345")
         assert response is None
 
+
 def test_delete_deployment_failure():
-    with patch('proxy.main.requests.delete') as mock_delete:
-        mock_delete.return_value.raise_for_status.side_effect = Exception('test error')
-        mock_delete.return_value.text = 'test error'
+    with patch("proxy.main.requests.delete") as mock_delete:
+        mock_delete.return_value.raise_for_status.side_effect = Exception("test error")
+        mock_delete.return_value.text = "test error"
         with pytest.raises(HTTPException) as excinfo:
-            delete_deployment('12345')
+            delete_deployment("12345")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'test error'
+        assert excinfo.value.detail == "test error"
 
 
 @pytest.mark.asyncio
 async def test_post_create_deployment_flow_run_success():
-    with patch('proxy.main.post_deployment_flow_run', return_value='test result'):
-        response = await post_create_deployment_flow_run('12345')
-        assert response == 'test result'
+    with patch("proxy.main.post_deployment_flow_run", return_value="test result"):
+        response = await post_create_deployment_flow_run("12345")
+        assert response == "test result"
+
 
 @pytest.mark.asyncio
 async def test_post_create_deployment_flow_run_failure():
-    with patch('proxy.main.post_deployment_flow_run', side_effect=Exception('test error')):
+    with patch(
+        "proxy.main.post_deployment_flow_run", side_effect=Exception("test error")
+    ):
         with pytest.raises(HTTPException) as excinfo:
-            await post_create_deployment_flow_run('12345')
+            await post_create_deployment_flow_run("12345")
         assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == 'failed to create flow_run for deployment'
+        assert excinfo.value.detail == "failed to create flow_run for deployment"
+
 
 def test_post_deployment_set_schedule_success():
-    with patch('proxy.main.set_deployment_schedule'):
-        response = post_deployment_set_schedule('12345', 'active')
-        assert response == {'success': 1}
+    with patch("proxy.main.set_deployment_schedule"):
+        response = post_deployment_set_schedule("12345", "active")
+        assert response == {"success": 1}
+
 
 def test_post_deployment_set_schedule_failure():
     with pytest.raises(HTTPException) as excinfo:
-        post_deployment_set_schedule('12345', 'invalid_status')
+        post_deployment_set_schedule("12345", "invalid_status")
     assert excinfo.value.status_code == 422
-    assert excinfo.value.detail == 'incorrect status value'
+    assert excinfo.value.detail == "incorrect status value"
 
 
 def test_post_deployment_set_schedule_with_invalid_status():
     with pytest.raises(HTTPException) as excinfo:
-        post_deployment_set_schedule('12345', 'invalid_status')
+        post_deployment_set_schedule("12345", "invalid_status")
     assert excinfo.value.status_code == 422
-    assert excinfo.value.detail == 'incorrect status value'
+    assert excinfo.value.detail == "incorrect status value"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -278,10 +278,13 @@ async def test_post_airbyte_server_with_invalid_payload():
         serverPort=8000,
         apiVersion="v1",
     )
-    with pytest.raises(HTTPException) as excinfo:
-        await post_airbyte_server(payload)
-    assert excinfo.value.status_code == 400
-    assert excinfo.value.detail == "failed to create airbyte server block"
+    with patch(
+        "proxy.main.create_airbyte_server_block", side_effect=Exception("test error")
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            await post_airbyte_server(payload)
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == "failed to create airbyte server block"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Prefect block names only allow lowercase letters, numbers and dashes. We ensure that our block names satisfy these rules with the `cleaned_name_for_prefectblock` function (formerly `cleaned_name_for_dbtblock`