### PR TITLE
dbt test failures caught

### DIFF
--- a/proxy/flows.py
+++ b/proxy/flows.py
@@ -99,8 +99,6 @@ def deployment_schedule_flow(airbyte_blocks: list, dbt_blocks: list):
             except Exception as error:  # skipcq PYL-W0703
                 logger.exception(error)
 
-            continue
-
         elif block["blockType"] == DBTCORE:
             dbt_op = DbtCoreOperation.load(block["blockName"])
             if os.path.exists(dbt_op.profiles_dir / "profiles.yml"):

--- a/proxy/flows.py
+++ b/proxy/flows.py
@@ -53,62 +53,62 @@ def run_dbtcore_flow(block_name: str):
 
 # =============================================================================
 # ==== deprecated soon after 2023-08-06
-# @flow
-# def deployment_schedule_flow(airbyte_blocks: list, dbt_blocks: list):
-#     # pylint: disable=broad-exception-caught
-#     """A general flow function that will help us create deployments"""
-#     # sort the dbt blocks by seq
-#     dbt_blocks.sort(key=lambda blk: blk["seq"])
+@flow
+def deployment_schedule_flow(airbyte_blocks: list, dbt_blocks: list):
+    # pylint: disable=broad-exception-caught
+    """A general flow function that will help us create deployments"""
+    # sort the dbt blocks by seq
+    dbt_blocks.sort(key=lambda blk: blk["seq"])
 
-#     # sort the airbyte blocks by seq
-#     airbyte_blocks.sort(key=lambda blk: blk["seq"])
+    # sort the airbyte blocks by seq
+    airbyte_blocks.sort(key=lambda blk: blk["seq"])
 
-#     # run airbyte blocks
-#     for block in airbyte_blocks:
-#         airbyte_connection = AirbyteConnection.load(block["blockName"])
-#         try:
-#             run_connection_sync(airbyte_connection)
-#         except Exception as error:  # skipcq PYL-W0703
-#             logger.exception(error)
+    # run airbyte blocks
+    for block in airbyte_blocks:
+        airbyte_connection = AirbyteConnection.load(block["blockName"])
+        try:
+            run_connection_sync(airbyte_connection)
+        except Exception as error:  # skipcq PYL-W0703
+            logger.exception(error)
 
-#     # run dbt blocks
-#     for block in dbt_blocks:
-#         if block["blockType"] == SHELLOPERATION:
-#             shell_op = ShellOperation.load(block["blockName"])
+    # run dbt blocks
+    for block in dbt_blocks:
+        if block["blockType"] == SHELLOPERATION:
+            shell_op = ShellOperation.load(block["blockName"])
 
-#             try:
-#                 # fetch the secret block having the git oauth token-based url to pull code from
-#                 # private repos
-#                 # the key "secret-git-pull-url-block" will always be present. Value will be empty
-#                 # string if no token was submitted by user
-#                 secret_block_name = shell_op.env["secret-git-pull-url-block"]
-#                 git_repo_endpoint = ""
-#                 if secret_block_name and len(secret_block_name) > 0:
-#                     secret_blk = Secret.load(secret_block_name)
-#                     git_repo_endpoint = secret_blk.get()
+            try:
+                # fetch the secret block having the git oauth token-based url to pull code from
+                # private repos
+                # the key "secret-git-pull-url-block" will always be present. Value will be empty
+                # string if no token was submitted by user
+                secret_block_name = shell_op.env["secret-git-pull-url-block"]
+                git_repo_endpoint = ""
+                if secret_block_name and len(secret_block_name) > 0:
+                    secret_blk = Secret.load(secret_block_name)
+                    git_repo_endpoint = secret_blk.get()
 
-#                 # update the commands to account for the token
-#                 commands = shell_op.commands
-#                 updated_cmds = []
-#                 for cmd in commands:
-#                     updated_cmds.append(f"{cmd} {git_repo_endpoint}")
-#                 shell_op.commands = updated_cmds
+                # update the commands to account for the token
+                commands = shell_op.commands
+                updated_cmds = []
+                for cmd in commands:
+                    updated_cmds.append(f"{cmd} {git_repo_endpoint}")
+                shell_op.commands = updated_cmds
 
-#                 # run the shell command(s)
-#                 shell_op.run()
-#             except Exception as error:  # skipcq PYL-W0703
-#                 logger.exception(error)
+                # run the shell command(s)
+                shell_op.run()
+            except Exception as error:  # skipcq PYL-W0703
+                logger.exception(error)
 
-#             continue
+            continue
 
-#         elif block["blockType"] == DBTCORE:
-#             dbt_op = DbtCoreOperation.load(block["blockName"])
-#             if os.path.exists(dbt_op.profiles_dir / "profiles.yml"):
-#                 os.unlink(dbt_op.profiles_dir / "profiles.yml")
-#             try:
-#                 dbt_op.run()
-#             except Exception as error:  # skipcq PYL-W0703
-#                 logger.exception(error)
+        elif block["blockType"] == DBTCORE:
+            dbt_op = DbtCoreOperation.load(block["blockName"])
+            if os.path.exists(dbt_op.profiles_dir / "profiles.yml"):
+                os.unlink(dbt_op.profiles_dir / "profiles.yml")
+            try:
+                dbt_op.run()
+            except Exception as error:  # skipcq PYL-W0703
+                logger.exception(error)
 
 
 # =============================================================================

--- a/proxy/flows.py
+++ b/proxy/flows.py
@@ -1,8 +1,12 @@
-"""Reusable flows"""
+"""
+Reusable flows
+https://docs.prefect.io/2.11.3/concepts/flows/#final-state-determination
+"""
 
 import os
-from prefect import flow
+from prefect import flow, task
 from prefect.blocks.system import Secret
+from prefect.states import State
 from prefect_airbyte.flows import run_connection_sync
 from prefect_airbyte import AirbyteConnection
 from prefect_dbt.cli.commands import DbtCoreOperation, ShellOperation
@@ -23,17 +27,14 @@ def run_airbyte_connection_flow(block_name: str):
     # pylint: disable=broad-exception-caught
     """Prefect flow to run airbyte connection"""
     try:
-        airbyte_connection = AirbyteConnection.load(block_name)
-        result = run_connection_sync(airbyte_connection)  # has three tasks
+        airbyte_connection: AirbyteConnection = AirbyteConnection.load(block_name)
+        result = run_connection_sync(airbyte_connection)
         logger.info("airbyte connection sync result=")
         logger.info(result)
         return result
     except Exception as error:  # skipcq PYL-W0703
-        # pylint: disable=broad-exception-caught
-        # logger.exception(error)
         logger.error(str(error))  # "Job <num> failed."
-
-    return None
+        raise
 
 
 @flow
@@ -41,67 +42,148 @@ def run_dbtcore_flow(block_name: str):
     # pylint: disable=broad-exception-caught
     """Prefect flow to run dbt"""
     try:
-        dbt_op = DbtCoreOperation.load(block_name)
+        dbt_op: DbtCoreOperation = DbtCoreOperation.load(block_name)
         if os.path.exists(dbt_op.profiles_dir / "profiles.yml"):
             os.unlink(dbt_op.profiles_dir / "profiles.yml")
         return dbt_op.run()
     except Exception as error:  # skipcq PYL-W0703
         logger.exception(error)
+        raise
 
-    return None
+
+# =============================================================================
+# ==== deprecated soon after 2023-08-06
+# @flow
+# def deployment_schedule_flow(airbyte_blocks: list, dbt_blocks: list):
+#     # pylint: disable=broad-exception-caught
+#     """A general flow function that will help us create deployments"""
+#     # sort the dbt blocks by seq
+#     dbt_blocks.sort(key=lambda blk: blk["seq"])
+
+#     # sort the airbyte blocks by seq
+#     airbyte_blocks.sort(key=lambda blk: blk["seq"])
+
+#     # run airbyte blocks
+#     for block in airbyte_blocks:
+#         airbyte_connection = AirbyteConnection.load(block["blockName"])
+#         try:
+#             run_connection_sync(airbyte_connection)
+#         except Exception as error:  # skipcq PYL-W0703
+#             logger.exception(error)
+
+#     # run dbt blocks
+#     for block in dbt_blocks:
+#         if block["blockType"] == SHELLOPERATION:
+#             shell_op = ShellOperation.load(block["blockName"])
+
+#             try:
+#                 # fetch the secret block having the git oauth token-based url to pull code from
+#                 # private repos
+#                 # the key "secret-git-pull-url-block" will always be present. Value will be empty
+#                 # string if no token was submitted by user
+#                 secret_block_name = shell_op.env["secret-git-pull-url-block"]
+#                 git_repo_endpoint = ""
+#                 if secret_block_name and len(secret_block_name) > 0:
+#                     secret_blk = Secret.load(secret_block_name)
+#                     git_repo_endpoint = secret_blk.get()
+
+#                 # update the commands to account for the token
+#                 commands = shell_op.commands
+#                 updated_cmds = []
+#                 for cmd in commands:
+#                     updated_cmds.append(f"{cmd} {git_repo_endpoint}")
+#                 shell_op.commands = updated_cmds
+
+#                 # run the shell command(s)
+#                 shell_op.run()
+#             except Exception as error:  # skipcq PYL-W0703
+#                 logger.exception(error)
+
+#             continue
+
+#         elif block["blockType"] == DBTCORE:
+#             dbt_op = DbtCoreOperation.load(block["blockName"])
+#             if os.path.exists(dbt_op.profiles_dir / "profiles.yml"):
+#                 os.unlink(dbt_op.profiles_dir / "profiles.yml")
+#             try:
+#                 dbt_op.run()
+#             except Exception as error:  # skipcq PYL-W0703
+#                 logger.exception(error)
+
+
+# =============================================================================
+@task(name="gitpulljob")
+def gitpulljob(shell_op_name: str):
+    # pylint: disable=broad-exception-caught
+    """loads and runs the git-pull shell operation"""
+    shell_op: ShellOperation = ShellOperation.load(shell_op_name)
+
+    # fetch the secret block having the git oauth token-based url to pull code
+    #  from private repos
+    # the key "secret-git-pull-url-block" will always be present. Value will be
+    #  empty string if no token was submitted by user
+    secret_block_name = shell_op.env["secret-git-pull-url-block"]
+    git_repo_endpoint = ""
+    if secret_block_name and len(secret_block_name) > 0:
+        secret_blk = Secret.load(secret_block_name)
+        git_repo_endpoint = secret_blk.get()
+
+    # update the commands to account for the token
+    commands = shell_op.commands
+    updated_cmds = []
+    for cmd in commands:
+        updated_cmds.append(f"{cmd} {git_repo_endpoint}")
+    shell_op.commands = updated_cmds
+
+    # run the shell command(s)
+    return shell_op.run()
+
+
+@task(name="dbtjob")
+def dbtjob(dbt_op_name: str):
+    # pylint: disable=broad-exception-caught
+    """
+    each dbt op will run as a task within the parent flow
+    errors are propagated to the flow except those from "dbt test"
+    """
+    dbt_op: DbtCoreOperation = DbtCoreOperation.load(dbt_op_name)
+
+    if os.path.exists(dbt_op.profiles_dir / "profiles.yml"):
+        os.unlink(dbt_op.profiles_dir / "profiles.yml")
+
+    try:
+        return dbt_op.run()
+    except Exception:  # skipcq PYL-W0703
+        if dbt_op_name.endswith("-test"):
+            return State(type="COMPLETED", message=f"WARNING: {dbt_op_name} failed")
+
+        raise
 
 
 @flow
-def deployment_schedule_flow(airbyte_blocks: list, dbt_blocks: list):
+def deployment_schedule_flow_v2(airbyte_blocks: list, dbt_blocks: list):
     # pylint: disable=broad-exception-caught
-    """A general flow function that will help us create deployments"""
-    # sort the dbt blocks by seq
-    dbt_blocks.sort(key=lambda blk: blk["seq"])
-
+    """modification so dbt test failures are not propagated as flow failures"""
     # sort the airbyte blocks by seq
     airbyte_blocks.sort(key=lambda blk: blk["seq"])
 
-    # run airbyte blocks
-    for block in airbyte_blocks:
-        airbyte_connection = AirbyteConnection.load(block["blockName"])
-        try:
+    # sort the dbt blocks by seq
+    dbt_blocks.sort(key=lambda blk: blk["seq"])
+
+    try:
+        # run airbyte blocks, fail if sync fails
+        for block in airbyte_blocks:
+            airbyte_connection = AirbyteConnection.load(block["blockName"])
             run_connection_sync(airbyte_connection)
-        except Exception as error:  # skipcq PYL-W0703
-            logger.exception(error)
 
-    # run dbt blocks
-    for block in dbt_blocks:
-        if block["blockType"] == SHELLOPERATION:
-            shell_op = ShellOperation.load(block["blockName"])
+        # run dbt blocks, fail on block failure unless the failing block is a dbt-test
+        for block in dbt_blocks:
+            if block["blockType"] == SHELLOPERATION:
+                gitpulljob(block["blockName"])
 
-            try:
-                # fetch the secret block having the git oauth token-based url to pull code from private repos
-                # the key "secret-git-pull-url-block" will always be present. Value will be empty string if no token was submitted by user
-                secret_block_name = shell_op.env["secret-git-pull-url-block"]
-                git_repo_endpoint = ""
-                if secret_block_name and len(secret_block_name) > 0:
-                    secret_blk = Secret.load(secret_block_name)
-                    git_repo_endpoint = secret_blk.get()
+            elif block["blockType"] == DBTCORE:
+                dbtjob(block["blockName"])
 
-                # update the commands to account for the token
-                commands = shell_op.commands
-                updated_cmds = []
-                for cmd in commands:
-                    updated_cmds.append(f"{cmd} {git_repo_endpoint}")
-                shell_op.commands = updated_cmds
-
-                # run the shell command(s)
-                shell_op.run()
-            except Exception as error:  # skipcq PYL-W0703
-                logger.exception(error)
-
-            continue
-
-        if block["blockType"] == DBTCORE:
-            dbt_op = DbtCoreOperation.load(block["blockName"])
-            if os.path.exists(dbt_op.profiles_dir / "profiles.yml"):
-                os.unlink(dbt_op.profiles_dir / "profiles.yml")
-            try:
-                dbt_op.run()
-            except Exception as error:  # skipcq PYL-W0703
-                logger.exception(error)
+    except Exception as error:  # skipcq PYL-W0703
+        logger.exception(error)
+        raise

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -29,7 +29,7 @@ from proxy.schemas import (
     PrefectSecretBlockCreate,
 )
 from proxy.flows import (
-    deployment_schedule_flow,
+    deployment_schedule_flow_v2,
 )
 
 load_dotenv()
@@ -548,7 +548,7 @@ async def post_deployment(payload: DeploymentCreate) -> dict:
     logger.info(payload)
 
     deployment = await Deployment.build_from_flow(
-        flow=deployment_schedule_flow.with_options(name=payload.flow_name),
+        flow=deployment_schedule_flow_v2.with_options(name=payload.flow_name),
         name=payload.deployment_name,
         work_queue_name="ddp",
         tags=[payload.org_slug],

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1129,10 +1129,10 @@ async def test_post_deployment_bad_payload():
 @pytest.mark.asyncio
 @patch("proxy.service.Deployment.build_from_flow", new_callable=AsyncMock)
 @patch(
-    "proxy.service.deployment_schedule_flow",
+    "proxy.service.deployment_schedule_flow_v2",
     new_callable=Mock,
 )
-async def test_post_deployment(deployment_schedule_flow, mock_build):
+async def test_post_deployment(deployment_schedule_flow_v2, mock_build):
     payload = DeploymentCreate(
         flow_name="flow-name",
         deployment_name="deployment-name",
@@ -1147,7 +1147,7 @@ async def test_post_deployment(deployment_schedule_flow, mock_build):
     deployment.name = "deployment-name"
 
     mock_build.return_value = deployment
-    deployment_schedule_flow.with_options = Mock(return_value="dsf")
+    deployment_schedule_flow_v2.with_options = Mock(return_value="dsf")
 
     response = await post_deployment(payload)
     assert response["id"] == "deployment-id"


### PR DESCRIPTION
Each dbt operation is now run within a `Task`

Stick to using `dbt_op.run()` rather than switching to `.trigger()` ... we catch any exceptions raised by the job and propagate them to the parent `Flow`, _unless_ the job is a `dbt test`. Failures of `dbt test` are reported as successful `Task` completions

Also failures of all other steps are no longer suppressed... we catch them to log the error but then re-raise 