### PR TITLE
increase the http timeout from 5 to 15 seconds when prefect initiates…

### DIFF
--- a/proxy/service.py
+++ b/proxy/service.py
@@ -250,8 +250,7 @@ async def create_airbyte_connection_block(
         ) from exc
 
     connection_block = AirbyteConnection(
-        airbyte_server=serverblock,
-        connection_id=conninfo.connectionId,
+        airbyte_server=serverblock, connection_id=conninfo.connectionId, timeout=15
     )
     try:
         block_name_for_save = cleaned_name_for_prefectblock(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -487,9 +487,10 @@ class MockAirbyteServer:
 
 
 class MockAirbyteConnection:
-    def __init__(self, airbyte_server, connection_id):
+    def __init__(self, airbyte_server, connection_id, timeout):
         self.airbyte_server = airbyte_server
         self.connection_id = connection_id
+        self.timeout = timeout
 
     async def save(self, block_name):
         if self.connection_id == "test_error_connection_id":


### PR DESCRIPTION
when prefect initiates an airbyte sync job, it `POST`s to airbyte's `/v1/connections/sync` endpoint with a default timeout of 5 seconds

we noticed some timeouts and are increasing this to 15 seconds